### PR TITLE
Change porter robinson regex to re.search

### DIFF
--- a/twitchbot/bot.py
+++ b/twitchbot/bot.py
@@ -170,7 +170,7 @@ class Bot:
 
         inner_re = '|'.join(porter_references).lower()
         phrases_re = r'(^|\W)({})($|\W)'.format(inner_re)
-        if re.match(phrases_re, message.lower()):
+        if re.search(phrases_re, message.lower()):
             self.send_msg(channel, '【=◈︿◈=】')
 
     def handle_timeout(self, channel, user, args):


### PR DESCRIPTION
should fix issue #1 where it didn't match keywords in the middle of messages since re.match only looks at the start of a string. re.search returns the same kind of results as re.match so there shouldn't be any issues with the replacement. https://docs.python.org/3/library/re.html#re.Pattern.search